### PR TITLE
feat: Migrate from nvim-web-devicons to mini.icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A fast bufferline based on nvchad's tabufline
 ```lua
 use {
     "nvoid-lua/bufferline.lua",
-    requires = 'nvim-tree/nvim-web-devicons',
+    requires = 'echasnovski/mini.icons',
     config = function()
         require("bufferline").setup({ kind_icons = true })
     end,
@@ -22,7 +22,7 @@ use {
 ```lua
 {
     "nvoid-lua/bufferline.lua",
-    dependencies = 'nvim-tree/nvim-web-devicons',
+    dependencies = 'echasnovski/mini.icons',
     config = function()
         require("bufferline").setup({ kind_icons = true })
     end,
@@ -36,15 +36,9 @@ require("bufferline").setup {
   always_show = false,
   show_numbers = false,
   kind_icons = true,
-  icons = {
-    unknown_file = "󰈚",
-    close = "󰅖",
-    modified = "",
-    tab = "󰌒",
-    tab_close = "󰅙",
-    tab_toggle = "",
-    tab_add = "",
-  },
+  -- Icons are now primarily sourced from 'mini.icons' if available.
+  -- Fallback icons are used internally if 'mini.icons' is not found or specific icons are missing.
+  -- You no longer need to configure the 'icons' table here for default behavior.
 }
 ```
 

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -54,16 +54,6 @@ function M.setup(opts)
 	M.always_show = opts.always_show or false
 	M.show_numbers = opts.show_numbers or false
 	M.kind_icons = opts.kind_icons or false
-	M.icons = opts.icons
-		or {
-			unknown_file = "󰈚",
-			close = "󰅖",
-			modified = "",
-			tab = "󰌒",
-			tab_close = "󰅙",
-			tab_toggle = "",
-			tab_add = "",
-		}
 
 	M.define_autocmds(require("bufferline.autocmd"))
 	M.show()

--- a/lua/bufferline/modules.lua
+++ b/lua/bufferline/modules.lua
@@ -1,7 +1,7 @@
 local api = vim.api
 local fn = vim.fn
 local utils = require("bufferline.utils")
-local icons = require("bufferline").icons
+local mini_icons_present, mini_icons = pcall(require, "mini.icons")
 utils.btns()
 
 local M = {}
@@ -41,25 +41,31 @@ M.tablist = function()
 	local result, number_of_tabs = "", fn.tabpagenr("$")
 
 	if number_of_tabs > 1 then
+		local tab_close_icon = mini_icons_present and mini_icons.get_icon_by_name("close") or "󰅙"
+		local tab_add_icon = mini_icons_present and mini_icons.get_icon_by_name("plus") or ""
+		local tab_icon = mini_icons_present and mini_icons.get_icon_by_name("folder") or "󰌒"
+		local tab_toggle_icon = mini_icons_present and mini_icons.get_icon_by_name("chevron_left") or ""
+
 		for i = 1, number_of_tabs, 1 do
 			local tab_hl = ((i == fn.tabpagenr()) and "%#TbLineTabOn# ") or "%#TbLineTabOff# "
 			result = result .. ("%" .. i .. "@TbGotoTab@" .. tab_hl .. i .. " ")
 			result = (
 				i == fn.tabpagenr()
-				and result .. "%#TbLineTabCloseBtn#" .. "%@TbTabClose@" .. icons.tab_close .. " %X"
+				and result .. "%#TbLineTabCloseBtn#" .. "%@TbTabClose@" .. tab_close_icon .. " %X"
 			) or result
 		end
 
-		local new_tabtn = "%#TblineTabNewBtn#" .. "%@TbNewTab@ " .. icons.tab_add .. "%X"
-		local tabstoggleBtn = "%@TbToggleTabs@ %#TBTabTitle# " .. icons.tab .. " %X"
+		local new_tabtn = "%#TblineTabNewBtn#" .. "%@TbNewTab@ " .. tab_add_icon .. "%X"
+		local tabstoggleBtn = "%@TbToggleTabs@ %#TBTabTitle# " .. tab_icon .. " %X"
 
-		return vim.g.TbTabsToggled == 1 and tabstoggleBtn:gsub("()", { [36] = icons.tab_toggle .. " " })
+		return vim.g.TbTabsToggled == 1 and tabstoggleBtn:gsub("()", { [36] = tab_toggle_icon .. " " })
 			or new_tabtn .. tabstoggleBtn .. result
 	end
 end
 
 M.buttons = function()
-	local CloseAllBufsBtn = "%@TbCloseAllBufs@%#TbLineCloseAllBufsBtn# " .. icons.close .. " %X"
+	local close_all_icon = mini_icons_present and mini_icons.get_icon_by_name("close") or "󰅖"
+	local CloseAllBufsBtn = "%@TbCloseAllBufs@%#TbLineCloseAllBufsBtn# " .. close_all_icon .. " %X"
 	return CloseAllBufsBtn
 end
 


### PR DESCRIPTION
This commit migrates the plugin from using nvim-web-devicons to mini.icons for displaying icons in the bufferline.

The following changes were made:
- Modified `lua/bufferline.lua` to remove hardcoded icons and use the `mini.icons` API to fetch icons dynamically.
- Updated `lua/bufferline/utils.lua` and `lua/bufferline/modules.lua` to use `mini.icons` for fetching icons.
- Updated `README.md` to reflect the change in dependency from `nvim-web-devicons` to `mini.icons`.